### PR TITLE
Fix Memory Leak When Client Disconnects

### DIFF
--- a/RakDotNet/TcpUdp/TcpUdpConnection.cs
+++ b/RakDotNet/TcpUdp/TcpUdpConnection.cs
@@ -157,7 +157,12 @@ namespace RakDotNet.TcpUdp
                     {
                         var packetLenBuffer = new byte[4];
 
-                        await _tcpStream.ReadAsync(packetLenBuffer, cancelToken).ConfigureAwait(false);
+                        var bytesRead = await _tcpStream.ReadAsync(packetLenBuffer, cancelToken).ConfigureAwait(false);
+                        if (bytesRead == 0)
+                        {
+                            await CloseAsync();
+                            break;
+                        }
 
                         var packetBuffer = new byte[BitConverter.ToInt32(packetLenBuffer)];
 


### PR DESCRIPTION
In Uchu, the memory usage of the authorization and character server starts at ~20MB and then go up to 150MB-200MB when a player logs in and connects to a world. This memory usage goes up uncontrollably with time due to the server attempting to process requests from disconnected clients. When a client disconnects, in `RunRecieveTcpAsync`, the `ReadAsync` method doesn't stop when the stream ends, resulting in the packet length of 0 being processed and invoking `OnPacket` with no payload and causing an `OutOfBoundException`. From testing, this happens tens of thousands of times with each disconnect. This fix stops processing when `ReadAsync` says it reads 0 bytes, which happens when the stream ends. With this fix, the Auth and Character server are both <60MB after the first login and don't increase uncontrollably with time.

This does not close any issues on Uchu because a pull request is required to use the new version of the submodule.